### PR TITLE
chore: disable CSS source maps in production

### DIFF
--- a/app/_config.yml
+++ b/app/_config.yml
@@ -56,6 +56,8 @@ exclude:
 
 sass:
   style: compressed
+  # Source maps only when JEKYLL_ENV=development (local serve); off in production deploy
+  sourcemap: development
 
 permalink: /:title/
 


### PR DESCRIPTION
Keep sourcemaps for local development; omit them from production deploys.